### PR TITLE
fix compat with Plone 4.3.8+

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,8 @@
 Changelog
 =========
-
+0.3.4 (unreleased)
+-------------------
+- Fix compatibility with Plone 4.3.x >= 4.3.8
 
 
 0.3.3 (2013)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='medialog.issuu',
       include_package_data=True,
       zip_safe=False,
       install_requires=['setuptools',
-                        'requests >= 0.9, < 1.0'
+                        'requests'
                         # -*- Extra requirements: -*-
                         ],
       tests_require=tests_require,


### PR DESCRIPTION
Plone 4.3.8 bumped the pinned version of requests to 2.9.1 (and 4.3.10 has 2.10.0),
conflicting with the "requests >= 0.9, < 1.0" pin here; see the history of https://github.com/plone/Installers-UnifiedInstaller/commits/4.3-maintenance/buildout_templates/buildout.cfg.

As this prevents the installation of medialog.issuu 0.3.3 (or of upgrading an existing Plone 4.3 with medialog.issuu installed) and 0.4 requires Plone 5, it is impossible to use medialog.issuu on the current version of Plone 4.  I've fixed this by removing the version pin for requests, and it appears to work fine -- at least files in my site display properly.

**Note:** I created a `plone4` branch from 4d67ba9 (the 0.3.3 release), then committed to that branch.  I didn't have any branch choice besides your master when creating the PR, but it doesn't belong there and makes more sense as a separate branch. You should be able to copy my branch, and hopefully cut a 0.3.4 release to pypi if it looks good.  Thanks!
